### PR TITLE
Bump NuGet packages

### DIFF
--- a/package/Stackage.Core.Tests/Stackage.Core.Tests.csproj
+++ b/package/Stackage.Core.Tests/Stackage.Core.Tests.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="7.1.0" />
-    <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
* Bump FluentAssertions from 5.10.3 to 6.0.0
* Bump FluentAssertions.Json from 5.5.0 to 6.0.0
* Bump Microsoft.NET.Test.Sdk from 16.10.0 to 16.11.0
* Bump NUnit3TestAdapter from 3.17.0 to 4.0.0